### PR TITLE
Fix: autoZoomConfiguration not working properly when the geojson parameter is passed

### DIFF
--- a/packages/components/src/components/Map.tsx
+++ b/packages/components/src/components/Map.tsx
@@ -100,6 +100,7 @@ export function Map({
     </div>
   ) : (
     <MapContainer
+      key={layersData}
       center={[center.latitude, center.longitude]}
       zoom={zoom}
       scrollWheelZoom={false}


### PR DESCRIPTION
If I pass the URL to the map, the autoZoomConfiguration works. However, if I pass an object in the GeoJSON, the autoZoomConfiguration doesn’t work. Therefore, I added a key to refresh the component when the values change.
here is the exemple
https://datahub.io/@RonaldojCampos/datahub-cloud-template-2